### PR TITLE
Remove Windows builds from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,20 @@ env:
   CARGO_INCREMENTAL: 0 # set here rather than on CI profile so that the tests get it too
 
 jobs:
+  skip_duplicate_jobs:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
   check-msrv:
+    needs: skip_duplicate_jobs
+    if: ${{ needs.skip_duplicate_jobs.outputs.should_skip != 'true' }}
     name: Check (MSRV)
     strategy:
       matrix:
@@ -39,6 +52,8 @@ jobs:
           command: check
           args: --profile=ci
   check:
+    needs: skip_duplicate_jobs
+    if: ${{ needs.skip_duplicate_jobs.outputs.should_skip != 'true' }}
     name: Check
     strategy:
       matrix:
@@ -70,6 +85,8 @@ jobs:
           command: check
           args: --profile=ci
   test:
+    needs: skip_duplicate_jobs
+    if: ${{ needs.skip_duplicate_jobs.outputs.should_skip != 'true' }}
     name: Test
     strategy:
       matrix:
@@ -101,6 +118,8 @@ jobs:
           command: test
           args: --all --profile=ci
   clippy:
+    needs: skip_duplicate_jobs
+    if: ${{ needs.skip_duplicate_jobs.outputs.should_skip != 'true' }}
     name: Clippy
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,12 +11,12 @@ jobs:
     name: Check (MSRV)
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         include:
           - os: ubuntu-latest
             deps: sudo apt-get update && sudo apt-get install libusb-1.0-0-dev libftdi1-dev libudev-dev
-          - os: windows-latest
-            deps: vcpkg install libusb libftdi1
+         #- os: windows-latest
+         #  deps: vcpkg install libusb libftdi1
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install dependencies
@@ -42,12 +42,12 @@ jobs:
     name: Check
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         include:
           - os: ubuntu-latest
             deps: sudo apt-get update && sudo apt-get install libusb-1.0-0-dev libftdi1-dev libudev-dev
-          - os: windows-latest
-            deps: vcpkg install libusb libftdi1
+         #- os: windows-latest
+         #  deps: vcpkg install libusb libftdi1
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install dependencies
@@ -73,12 +73,12 @@ jobs:
     name: Test
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         include:
           - os: ubuntu-latest
             deps: sudo apt-get update && sudo apt-get install libusb-1.0-0-dev libftdi1-dev libudev-dev
-          - os: windows-latest
-            deps: vcpkg install libusb libftdi1
+         #- os: windows-latest
+         #  deps: vcpkg install libusb libftdi1
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install dependencies


### PR DESCRIPTION
None of our development is done on Windows, so running CI for it takes
needless time.