### PR TITLE
Add nix flake

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,0 +1,23 @@
+name: "Nix flake checks"
+on:
+  pull_request:
+  push:
+jobs:
+  linux-checks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v15
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+    - run: nix flake check
+  darwin-checks:
+    runs-on: macOS-latest 
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v15
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+    - run: nix flake check

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 /target
+result
+.cargo/.package-cache
+.cargo/git/
+.cargo/registry/
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,67 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1663264531,
+        "narHash": "sha256-2ncO5chPXlTxaebDlhx7MhL0gOEIWxzSyfsl0r0hxQk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "454887a35de6317a30be284e8adc2d2f6d8a07c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1663297375,
+        "narHash": "sha256-7pjd2x9fSXXynIzp9XiXjbYys7sR6MKCot/jfGL7dgE=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "0678b6187a153eb0baa9688335b002fe14ba6712",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,67 @@
+{
+  description = "Flake shell to open Humility dev environment";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  inputs.rust-overlay.url = "github:oxalica/rust-overlay";
+  inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.rust-overlay.inputs.flake-utils.follows = "flake-utils";
+
+  outputs = {
+    self,
+    nixpkgs,
+    rust-overlay,
+    flake-utils,
+  }: (flake-utils.lib.eachDefaultSystem (system: let
+    overlays = [(import rust-overlay)];
+
+    pkgs = import nixpkgs {
+      inherit system overlays;
+    };
+
+    rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+    humility-overlay = final: prev: {
+      cargo = rust;
+      rustc = rust;
+      humility = final.callPackage ./humility.nix {
+        cargo = rust;
+        src = self;
+        version = "0.8.10";
+        inherit (prev.darwin.apple_sdk.frameworks) AppKit;
+      };
+    };
+
+    humility-overlays = [humility-overlay];
+    humility-pkgs = import nixpkgs {
+      inherit system;
+      overlays = humility-overlays;
+    };
+  in {
+    packages = flake-utils.lib.flattenTree {
+      humility = humility-pkgs.humility;
+      default = humility-pkgs.humility;
+    };
+
+    devShells.default = pkgs.mkShell {
+      shellHook = ''
+        export CARGO_HOME=$(pwd)/.cargo
+        export PATH="$(pwd)/.cargo/bin:$PATH"
+      '';
+
+      nativeBuildInputs = with pkgs;
+        [
+          rust
+          cargo-readme
+          openocd
+          libusb1
+        ]
+        # this is needed for libudev
+        ++ lib.optionals pkgs.stdenv.isLinux [pkgs.systemd];
+    };
+
+    checks = {
+      humility = humility-pkgs.humility.override {doCheck = true;};
+    };
+  }));
+}

--- a/humility.nix
+++ b/humility.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  cargo,
+  pkg-config,
+  systemd ? null,
+  AppKit ? null,
+  libusb1,
+  cargo-readme,
+  src,
+  version,
+  doCheck ? false,
+}:
+rustPlatform.buildRustPackage rec {
+  inherit src version doCheck;
+
+  name = "humility";
+
+  cargoSha256 = "sha256-Sjk1XkpRA8eVucgRcY0OFyaNs1wvnBhaCt6yF2E1Xdw";
+
+  nativeBuildInputs =
+    [
+      pkg-config
+      cargo-readme
+      cargo
+    ]
+    ++ lib.optionals stdenv.isDarwin [AppKit];
+
+  buildInputs =
+    [
+      libusb1
+      cargo-readme
+    ]
+    ++ lib.optionals stdenv.isLinux [systemd];
+
+  checkPhase = ''
+    ${cargo}/bin/cargo fmt --all --check
+    ${cargo}/bin/cargo clippy --profile=ci -- -D warnings
+    ${cargo}/bin/cargo test
+  '';
+
+  meta = with lib; {
+    description = "Humility is the debugger for Hubris";
+    homepage = "https://github.com/oxidecomputer/humility";
+    license = licenses.mpl20;
+  };
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.59.0"
+components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
Adds:

- Nix builder for humility that is capable of running the full humility test suite.
- Flake that setups the development environment and exposes the humility package.
- CI pipeline that runs on both linux and macos.

You can build humility by running `nix build "git+ssh://git@github.com/rivosinc/humility.git?ref=dev/drew/nix_ci"`.  The output will be in the `result` folder.  You can also enter an environment with humility available by running `nix shell "git+ssh://git@github.com/rivosinc/humility.git?ref=dev/drew/nix_ci"`