### PR TITLE
Enables register reading through the gdb server in qemu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,6 +1874,7 @@ dependencies = [
  "parse_int",
  "probe-rs",
  "regex",
+ "roxmltree",
  "rusb",
  "rustc-demangle",
  "scroll",
@@ -1884,6 +1885,7 @@ dependencies = [
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "toml",
+ "xmlparser",
  "zip",
 ]
 
@@ -2773,6 +2775,15 @@ dependencies = [
  "base64",
  "bitflags",
  "serde",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b9de9831a129b122e7e61f242db509fa9d0838008bf0b29bb0624669edfe48a"
+dependencies = [
+ "xmlparser",
 ]
 
 [[package]]
@@ -3724,6 +3735,12 @@ name = "xml-rs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
 
 [[package]]
 name = "xtask"

--- a/humility-core/Cargo.toml
+++ b/humility-core/Cargo.toml
@@ -33,6 +33,8 @@ colored = "2.0.0"
 strum = "0.24.1"
 strum_macros = "0.24.1"
 clap = "3.0.12"
+roxmltree = "0.15"
+xmlparser = "0.13"
 
 #
 # We depend on the oxide-stable branch of Oxide's fork of probe-rs to assure

--- a/humility-core/src/core/gdb.rs
+++ b/humility-core/src/core/gdb.rs
@@ -374,7 +374,10 @@ impl Core for GDBCore {
 
     fn read_reg(&mut self, reg: Register) -> Result<u32> {
         log::trace!("reading reg: {:?}", reg);
-        let reg_id = if self.reg_table.is_empty() {
+        let reg_id = if self.reg_table.is_empty()
+            || reg.is_general_purpose()
+            || reg.is_pc()
+        {
             reg.to_gdb_id()
         } else {
             let reg_string = reg.to_string().to_lowercase();

--- a/humility-core/src/core/openocd.rs
+++ b/humility-core/src/core/openocd.rs
@@ -197,14 +197,9 @@ impl Core for OpenOCDCore {
     }
 
     fn read_reg(&mut self, reg: Register) -> Result<u32> {
-        let mut reg_id = Register::to_u16(&reg).unwrap();
-        if let Register::RiscV(rv_reg) = reg {
-            log::trace!("converting register id for openocd");
-            reg_id = rv_reg.to_gdb_id();
-        }
+        let reg_id = reg.to_gdb_id();
 
         self.op_start()?;
-        use num_traits::ToPrimitive;
 
         let cmd = format!("reg {}", reg_id);
         let rval = self.sendcmd(&cmd)?;

--- a/humility-core/src/regs/arm.rs
+++ b/humility-core/src/regs/arm.rs
@@ -86,6 +86,10 @@ pub enum ARMRegister {
 }
 
 impl ARMRegister {
+    pub fn to_gdb_id(&self) -> u32 {
+        ARMRegister::to_u32(self).unwrap()
+    }
+
     pub fn is_general_purpose(&self) -> bool {
         matches!(
             self,

--- a/humility-core/src/regs/mod.rs
+++ b/humility-core/src/regs/mod.rs
@@ -56,6 +56,12 @@ impl Register {
             Register::RiscV(reg) => reg.fields(),
         }
     }
+    pub fn to_gdb_id(&self) -> u32 {
+        match self {
+            Register::Arm(reg) => reg.to_gdb_id(),
+            Register::RiscV(reg) => reg.to_gdb_id(),
+        }
+    }
 }
 
 impl ToPrimitive for Register {

--- a/humility-core/src/regs/mod.rs
+++ b/humility-core/src/regs/mod.rs
@@ -32,6 +32,12 @@ pub enum Register {
 }
 
 impl Register {
+    pub fn is_pc(&self) -> bool {
+        match self {
+            Register::Arm(reg) => *reg == ARMRegister::PC,
+            Register::RiscV(reg) => *reg == RVRegister::PC,
+        }
+    }
     pub fn is_general_purpose(&self) -> bool {
         match self {
             Register::Arm(reg) => reg.is_general_purpose(),

--- a/humility-core/src/regs/rv.rs
+++ b/humility-core/src/regs/rv.rs
@@ -252,13 +252,13 @@ impl RVRegister {
     /// The difference being that the CSR are offset by 65
     /// While the debug module itself expects https://raw.githubusercontent.com/riscv/riscv-debug-spec/master/riscv-debug-stable.pdf#table.3.3
     ///
-    pub fn to_gdb_id(&self) -> u16 {
+    pub fn to_gdb_id(&self) -> u32 {
         // pc is at a special index
         if self == &RVRegister::PC {
             return 32;
         }
 
-        let mut reg_id = RVRegister::to_u16(self).unwrap();
+        let mut reg_id = RVRegister::to_u32(self).unwrap();
         if !self.is_special() {
             reg_id -= 0x1000;
         } else {

--- a/humility.nix
+++ b/humility.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
 
   name = "humility";
 
-  cargoSha256 = "sha256-g12cHSbzCVBYZYHxV2mSEfueWcjSjsnUr6tlpjLuUE8";
+  cargoSha256 = "sha256-5/TJwXc4auhhfxsLHipch5RWMMPF5MEyH+pPkboaG04";
 
   nativeBuildInputs =
     [


### PR DESCRIPTION
This was broken for 2 reasons before.
First, we had to send the magic `qXfer:features:read:target.xml` packet to enable reading individual registers.  
Then the qemu gdb server provides its own mapping of registers name to numbers that we needed to follow.  This mapping is different, and is calculated at runtime based on what CSRs are included in the vm.