### PR TITLE
Adds `humility tasks` support for rv64

### DIFF
--- a/cmd/diagnose/src/lib.rs
+++ b/cmd/diagnose/src/lib.rs
@@ -417,7 +417,8 @@ fn find_task_names<'a>(
         .into_iter()
         .map(|desc| {
             hubris
-                .instr_mod(desc.entry_point)
+                // TODO the u32 cast will be removed once there is full 64bit support
+                .instr_mod(desc.entry_point as u32)
                 .unwrap_or("<unknown>")
                 .to_string()
         })

--- a/cmd/tasks/src/lib.rs
+++ b/cmd/tasks/src/lib.rs
@@ -206,7 +206,7 @@ fn tasks(context: &mut humility::ExecutionContext) -> Result<()> {
         core.halt()?;
 
         let cur =
-            core.read_word_32(hubris.lookup_symword("CURRENT_TASK_PTR")?)?;
+            hubris.arch.as_ref().unwrap().get_current_task_ptr(hubris, core)?;
 
         //
         // We read the entire task table at a go to get as consistent a

--- a/cmd/tasks/src/lib.rs
+++ b/cmd/tasks/src/lib.rs
@@ -206,7 +206,8 @@ fn tasks(context: &mut humility::ExecutionContext) -> Result<()> {
         core.halt()?;
 
         let cur =
-            hubris.arch.as_ref().unwrap().get_current_task_ptr(hubris, core)?;
+            hubris.arch.as_ref().unwrap().get_current_task_ptr(hubris, core)?
+                as u32;
 
         //
         // We read the entire task table at a go to get as consistent a
@@ -335,7 +336,13 @@ fn tasks(context: &mut humility::ExecutionContext) -> Result<()> {
                 let regs = hubris.registers(core, t)?;
 
                 if subargs.stack {
-                    match hubris.stack(core, t, desc.initial_stack, &regs) {
+                    // TODO: the u32 cast wont be required once hubris core has 64bit support
+                    match hubris.stack(
+                        core,
+                        t,
+                        desc.initial_stack as u32,
+                        &regs,
+                    ) {
                         Ok(stack) => printer.print(hubris, &stack),
                         Err(e) => {
                             println!("   stack unwind failed: {:?} ", e);

--- a/humility-cmd/src/doppel.rs
+++ b/humility-cmd/src/doppel.rs
@@ -38,10 +38,42 @@ use humility::reflect::{Load, Ptr, Value};
 use std::convert::TryInto;
 use zerocopy::{AsBytes, LittleEndian, U16, U64};
 
+// this struct exist to just help load the 32 bit task desc
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Load)]
-pub struct TaskDesc {
+pub struct TaskDesc32 {
     pub entry_point: u32,
     pub initial_stack: u32,
+}
+
+// this struct exist to just help load the 64 bit task desc
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Load)]
+pub struct TaskDesc64 {
+    pub entry_point: u64,
+    pub initial_stack: u64,
+}
+// This struct will be used by the rest of humility to represent a task desc
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct TaskDesc {
+    pub entry_point: u64,
+    pub initial_stack: u64,
+}
+
+impl humility::reflect::Load for TaskDesc {
+    fn from_value(v: &Value) -> Result<Self> {
+        if let Ok(td) = TaskDesc32::from_value(v) {
+            Ok(Self {
+                entry_point: td.entry_point as u64,
+                initial_stack: td.initial_stack as u64,
+            })
+        } else if let Ok(td) = TaskDesc64::from_value(v) {
+            Ok(Self {
+                entry_point: td.entry_point,
+                initial_stack: td.initial_stack,
+            })
+        } else {
+            bail!("unexpected task description: {:?}", v)
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Load)]

--- a/humility-core/src/arch/arm.rs
+++ b/humility-core/src/arch/arm.rs
@@ -216,6 +216,13 @@ impl Arch for ARMArch {
         None
     }
 
+    fn get_current_task_ptr(
+        &self,
+        hubris: &HubrisArchive,
+        core: &mut dyn crate::core::Core,
+    ) -> Result<u32> {
+        core.read_word_32(hubris.lookup_symword("CURRENT_TASK_PTR")?)
+    }
     //
     // On ARM, our stub frames (that is, those frames that contain system call
     // instructions) have no DWARF information that describes how to unwind

--- a/humility-core/src/arch/arm.rs
+++ b/humility-core/src/arch/arm.rs
@@ -220,8 +220,9 @@ impl Arch for ARMArch {
         &self,
         hubris: &HubrisArchive,
         core: &mut dyn crate::core::Core,
-    ) -> Result<u32> {
-        core.read_word_32(hubris.lookup_symword("CURRENT_TASK_PTR")?)
+    ) -> Result<u64> {
+        Ok(core.read_word_32(hubris.lookup_symword("CURRENT_TASK_PTR")?)?
+            as u64)
     }
     //
     // On ARM, our stub frames (that is, those frames that contain system call

--- a/humility-core/src/arch/mod.rs
+++ b/humility-core/src/arch/mod.rs
@@ -68,6 +68,12 @@ pub trait Arch {
 
     fn get_generic_chip(&self) -> String;
 
+    fn get_current_task_ptr(
+        &self,
+        hubris: &HubrisArchive,
+        core: &mut dyn crate::core::Core,
+    ) -> Result<u32>;
+
     fn presyscall_pushes(
         &self,
         cs: &Capstone,

--- a/humility-core/src/arch/mod.rs
+++ b/humility-core/src/arch/mod.rs
@@ -72,7 +72,7 @@ pub trait Arch {
         &self,
         hubris: &HubrisArchive,
         core: &mut dyn crate::core::Core,
-    ) -> Result<u32>;
+    ) -> Result<u64>;
 
     fn presyscall_pushes(
         &self,

--- a/humility-core/src/arch/rv.rs
+++ b/humility-core/src/arch/rv.rs
@@ -82,18 +82,15 @@ impl Arch for RVArch {
         &self,
         hubris: &HubrisArchive,
         core: &mut dyn crate::core::Core,
-    ) -> Result<u32> {
-        core.read_word_32(hubris.lookup_symword("CURRENT_TASK_PTR")?)
-
-        //TODO
-        //match hubris.lookup_symword("CURRENT_TASK_PTR") {
-        //Ok(ptr) => core.read_word_32(ptr),
-        // Means current task is in mscratch or sscratch, but only if on riscv
-        //Err(_) => {
-        // TODO right now blindly check mscratch, but should check that it is valid
-        //core.read_reg(Register::RiscV(RVRegister::MSCRATCH))
-        //}
-        //}
+    ) -> Result<u64> {
+        match hubris.lookup_symword("CURRENT_TASK_PTR") {
+            Ok(ptr) => Ok(core.read_word_32(ptr)? as u64),
+            // Means current task is in mscratch or sscratch, but only if on riscv
+            Err(_) => {
+                // TODO right now blindly check mscratch, but should check that it is valid
+                core.read_reg(Register::RiscV(RVRegister::MSCRATCH))
+            }
+        }
     }
 
     ///

--- a/humility-core/src/arch/rv.rs
+++ b/humility-core/src/arch/rv.rs
@@ -72,6 +72,30 @@ impl Arch for RVArch {
         RVRegister::iter().map(Register::RiscV).collect()
     }
 
+    //
+    // TODO: will first check for `CURRENT_TASK_PTR` then check mscratch/sscratch,
+    // When using xscratch, there is a small time when the current task ptr is
+    // actually in a0 when handling a trap, we can detect this and read the
+    // correct register.
+    //
+    fn get_current_task_ptr(
+        &self,
+        hubris: &HubrisArchive,
+        core: &mut dyn crate::core::Core,
+    ) -> Result<u32> {
+        core.read_word_32(hubris.lookup_symword("CURRENT_TASK_PTR")?)
+
+        //TODO
+        //match hubris.lookup_symword("CURRENT_TASK_PTR") {
+        //Ok(ptr) => core.read_word_32(ptr),
+        // Means current task is in mscratch or sscratch, but only if on riscv
+        //Err(_) => {
+        // TODO right now blindly check mscratch, but should check that it is valid
+        //core.read_reg(Register::RiscV(RVRegister::MSCRATCH))
+        //}
+        //}
+    }
+
     ///
     /// on RISCV platforms the dwarf id does not match the register id on the bus.
     /// see: https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-dwarf.adoc


### PR DESCRIPTION
Currently, it assumes `mscratch` will be valid.  See https://rivosinc.atlassian.net/browse/SW-908 to track proper validation of the task pointer.  Currently if `mscratch` is not valid, it will just throw a error about having an incorrect structure.  The odds if this happening are extremely slim though.