### PR TITLE
cmd: gdb: update elf path to work with new `script.gdb`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,6 +1271,7 @@ dependencies = [
  "humility-cmd",
  "humility-cmd-openocd",
  "humility-core",
+ "regex",
  "tempfile",
 ]
 

--- a/cmd/gdb/Cargo.toml
+++ b/cmd/gdb/Cargo.toml
@@ -14,3 +14,4 @@ anyhow = { version = "1.0.44", features = ["backtrace"] }
 clap = { version = "3.0.12", features = ["derive", "env"] }
 ctrlc = "3.1.5"
 tempfile = "3.3"
+regex = "1.5"

--- a/humility.nix
+++ b/humility.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
 
   name = "humility";
 
-  cargoSha256 = "sha256-5/TJwXc4auhhfxsLHipch5RWMMPF5MEyH+pPkboaG04";
+  cargoSha256 = "sha256-GNJLQHkAB434oGKWFbnosPNfAiUT1nAPpnx2HW7CRNo";
 
   nativeBuildInputs =
     [


### PR DESCRIPTION
Hubris PR https://github.com/rivosinc/hubris/pull/76 and https://github.com/rivosinc/hubris/pull/73 broke `humility gdb` by changing the paths in the `scripts.gdb`.  This change adds support for this change.

The caveat here is that it breaks support with all hubris archives predating hubris hash `f1e8bce17758e1b57aaba340370f21a3bf142e0d` on rivos/main and `ba2b47e9a10308c6cecef138e1a31da606714e62` on rivos/main-rv64.