### PR TITLE
ci: add gitlab CI for pushing to rivos binary cache

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,14 @@
+nix-cache:
+  stage: build
+  image: $RIVOS_NIX_IMG 
+  variables:
+    INSTALLABLES: '.#humility'
+    NIX_CONFIG: |
+      experimental-features = nix-command flakes
+      extra-substituters = $RIVOS_NIX_CACHE 
+      extra-trusted-public-keys = $RIVOS_NIX_CACHE_PUB_KEY 
+      max-jobs = auto 
+  script:
+    # no need to rerun the whole test suite, the github CI does that already, just need to build and cache it
+    - nix build --print-build-logs ${INSTALLABLES}
+    - push-rivos-cache ${INSTALLABLES}


### PR DESCRIPTION
This won't actually run here, but only on our gitlab CI.  This should make the binaries available to other CI jobs and to the developer environment for hubris.  You can see the job [here](https://gitlab.ba.rivosinc.com/rv/sw/ext/humility/-/jobs/279979) .