### PR TITLE
cmd: gdb: add `gdb` as possible gdb executable.

### DIFF
--- a/cmd/gdb/src/lib.rs
+++ b/cmd/gdb/src/lib.rs
@@ -85,7 +85,7 @@ pub fn gdb(context: &mut humility::ExecutionContext) -> Result<()> {
 
     let mut gdb_cmd = None;
 
-    const GDB_NAMES: [&str; 4] = [
+    const GDB_NAMES: [&str; 5] = [
         "arm-none-eabi-gdb",
         "riscv32-none-elf-gdb",
         "riscv32-unknown-elf-gdb",

--- a/cmd/gdb/src/lib.rs
+++ b/cmd/gdb/src/lib.rs
@@ -90,6 +90,7 @@ pub fn gdb(context: &mut humility::ExecutionContext) -> Result<()> {
         "riscv32-none-elf-gdb",
         "riscv32-unknown-elf-gdb",
         "gdb-multiarch",
+        "gdb",
     ];
     for candidate in &GDB_NAMES {
         if Command::new(candidate)


### PR DESCRIPTION
On some system `gdb` has multiarch support, rather than `gdb-multiarch`