### PR TITLE
Missed a `CURRENT_TASK_PTR`

### DIFF
--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -3310,7 +3310,7 @@ impl HubrisArchive {
     ) -> Result<BTreeMap<Register, u32>> {
         let (base, _) = self.task_table(core)?;
         let cur =
-            core.read_word_32(self.lookup_symword("CURRENT_TASK_PTR")?)?;
+            self.arch.as_ref().unwrap().get_current_task_ptr(self, core)?;
 
         let module = self.lookup_module(t)?;
         let mut rval = BTreeMap::new();
@@ -3335,7 +3335,7 @@ impl HubrisArchive {
         //
         // If this is the current task, we want to pull the current PC.
         //
-        if offset - save == cur {
+        if offset - save == cur as u32 {
             let pc =
                 core.read_reg(self.arch.as_ref().unwrap().get_pc())? as u32;
 


### PR DESCRIPTION
This bug would manifest as a panic when calling `humility task -r` if a scratch register was used at the task ptr.