### PR TITLE
humility-core: core: gdb: fix bug when connecting to qemu.

### DIFF
--- a/humility-core/src/core/gdb.rs
+++ b/humility-core/src/core/gdb.rs
@@ -237,7 +237,6 @@ impl GDBCore {
                 }
                 log::trace!("connected to running core");
                 core.was_halted = false;
-                core.run()?;
             }
         };
 
@@ -252,6 +251,7 @@ impl GDBCore {
         log::trace!("feature read string: {:?}", feature_read);
         core.feature_xml_parser(feature_read.as_str());
         log::trace!("reg table: {:?}", core.reg_table);
+        core.run()?;
         Ok(core)
     }
 


### PR DESCRIPTION
When connecting to a running qemu instance, humility would fail to properly connect due to restarting the core too early.  When the core was running, it does not respond as expected to other packets.  This commit moves the `core.run` to the end of the initialization procedure.