### PR TITLE
nix: add precommit hooks for formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ result
 .cargo/.package-cache
 .cargo/git/
 .cargo/registry/
+.pre-commit-config.yaml
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1663264531,
-        "narHash": "sha256-2ncO5chPXlTxaebDlhx7MhL0gOEIWxzSyfsl0r0hxQk=",
+        "lastModified": 1667909632,
+        "narHash": "sha256-p9ZTU29fRA0KNQVGIFTA06IcVeoCqYNRvegRdxGZd8k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "454887a35de6317a30be284e8adc2d2f6d8a07c4",
+        "rev": "bc5ad970780580ec272b3a6bc5f9bddf4e250d3c",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1663297375,
-        "narHash": "sha256-7pjd2x9fSXXynIzp9XiXjbYys7sR6MKCot/jfGL7dgE=",
+        "lastModified": 1667875464,
+        "narHash": "sha256-0rO2Pzn//ANT3AphpEUantCbm86XcmKNEKhM73LFr04=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0678b6187a153eb0baa9688335b002fe14ba6712",
+        "rev": "9235990723630e1a55e1ed6bca5954e4e31cfbd7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -31,10 +31,34 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1667760143,
+        "narHash": "sha256-+X5CyeNEKp41bY/I1AJgW/fn69q5cLJ1bgiaMMCKB3M=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "06f48d63d473516ce5b8abe70d15be96a0147fcd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,6 @@
           files = "\\.rs$";
           pass_filenames = false;
         };
-        alejandra.enable = true;
       };
     };
   in {


### PR DESCRIPTION
This includes formatting git hooks for rust and nix.  These hooks will get loading when loading `nix develop`, and only get ran when you change a file they apply to.  See https://github.com/cachix/pre-commit-hooks.nix for more info on how it works.
Example output when running `git commit`:
```> git commit                                                                       13:28:59
alejandra............................................(no files to check)Skipped
cargo fmt................................................................Failed
- hook id: cargofmt
- exit code: 1

Diff in /home/azoghby/env/humility/cmd/probe/src/lib.rs at line 200:
                     patch.patch_version(),
                 )
             } else {
-
                 format!("<unknown NXP M33 0x{:x}>", coreinfo.manufacturer_part)
             }
         } else {
```

I often find myself forgetting to `cargo fmt` so hopefully this will help prevent having to run `cargo fmt` and rebase.