### PR TITLE
Add ability to launch another humility command along with qemu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1472,6 +1472,12 @@ The `--wait` option instructs qemu to wait for a gdb client to connect
 
 The `--gdb` option can be used to launch qemu and then open a gdb console connected to it
 
+The `--silent` option will hide qemu's stdout
+
+The `--command` option specifies another humility command to run after launching qemu
+
+The `--delay` option is how long to wait, in ms,  before running `command`
+
 This works by parsing the qemu.sh file within the chip folder
 (`<hubris>/chips/<chipname>/qemu.sh`), then adding additional args to configure gdb
 

--- a/cmd/qemu/src/lib.rs
+++ b/cmd/qemu/src/lib.rs
@@ -114,10 +114,7 @@ fn qemu(context: &mut humility::ExecutionContext) -> Result<()> {
     }
     let qemu_w_args: Vec<&str> = qemu_cmd.split(' ').collect();
 
-    humility::msg!("Running: {}", qemu_cmd);
-
     let mut cmd = Command::new(qemu_w_args[0]);
-    humility::msg!("base cmd: {:?}", cmd);
     cmd.current_dir(work_dir.path());
 
     //skip first word
@@ -137,7 +134,7 @@ fn qemu(context: &mut humility::ExecutionContext) -> Result<()> {
         cmd.stdout(Stdio::null());
     }
 
-    humility::msg!("full cmd: {:?}", cmd);
+    humility::msg!("launching qemu: {:?}", cmd);
 
     // If running with immediate gdb attachment,  need to run qemu in the "background"
     struct Runner(std::process::Child);

--- a/cmd/qemu/src/lib.rs
+++ b/cmd/qemu/src/lib.rs
@@ -12,6 +12,12 @@
 //!
 //! The `--gdb` option can be used to launch qemu and then open a gdb console connected to it
 //!
+//! The `--silent` option will hide qemu's stdout
+//!
+//! The `--command` option specifies another humility command to run after launching qemu
+//!
+//! The `--delay` option is how long to wait, in ms,  before running `command`
+//!
 //! This works by parsing the qemu.sh file within the chip folder
 //! (`<hubris>/chips/<chipname>/qemu.sh`), then adding additional args to configure gdb
 //!

--- a/cmd/qemu/src/lib.rs
+++ b/cmd/qemu/src/lib.rs
@@ -59,6 +59,10 @@ struct QemuArgs {
         requires = "command"
     )]
     delay: u64,
+
+    /// Hide qemu stdout
+    #[clap(long, short)]
+    silent: bool,
 }
 
 fn qemu(context: &mut humility::ExecutionContext) -> Result<()> {
@@ -121,6 +125,10 @@ fn qemu(context: &mut humility::ExecutionContext) -> Result<()> {
 
     if subargs.wait || subargs.gdb {
         cmd.arg("-S");
+    }
+
+    if subargs.silent {
+        cmd.stdout(Stdio::null());
     }
 
     humility::msg!("full cmd: {:?}", cmd);


### PR DESCRIPTION
Adds ability to launch qemu, then another command a certain time after. ex: `humility qemu -c tasks --delay 500` will run `humility tasks` 500ms after qemu launches, then exit.  Additionally `humility qemu -c tasks --delay 500 --silent` would hide the `qemu` stdout and only show `tasks` stdout.  
The primary motivation for this is being able to easily run commands targeting qemu cores within the humility test suite.  Additionally, when testing commands, I often find myself following the same pattern.

~~This is marked to merge into `dev/drew/gdb_ports` to represent the dependency on https://github.com/rivosinc/humility/pull/34.~~  Without being able to specify the port, there would be no guarantee we are connecting to the right qemu instance.