### PR TITLE
nix: added dependency AppKit to nativeBuildInputs for macOS platform

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,8 @@
           libusb1
         ]
         # this is needed for libudev
-        ++ lib.optionals pkgs.stdenv.isLinux [pkgs.systemd];
+        ++ lib.optionals pkgs.stdenv.isLinux [pkgs.systemd]
+        ++ lib.optionals stdenv.isDarwin [darwin.apple_sdk.frameworks.AppKit];
     };
 
     checks = {


### PR DESCRIPTION
This fixes linker error when it's running on Darwin platform: `ld: framework not found AppKit`