### PR TITLE
rust: updated rust-toolchain to latest stable 1.65.0 version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 name: Continuous integration
 
 env:
-  MSRV: 1.59.0
+  MSRV: 1.65.0
   CARGO_INCREMENTAL: 0 # set here rather than on CI profile so that the tests get it too
 
 jobs:

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -67,7 +67,7 @@ fn dumpcmd(context: &mut humility::ExecutionContext) -> Result<()> {
 
     let subargs = DumpArgs::try_parse_from(subargs)?;
 
-    let _info = core.halt()?;
+    core.halt()?;
     humility::msg!("core halted");
 
     let rval = hubris.dump(core, subargs.dumpfile.as_deref());

--- a/cmd/etm/src/lib.rs
+++ b/cmd/etm/src/lib.rs
@@ -590,7 +590,7 @@ fn etmcmd(context: &mut humility::ExecutionContext) -> Result<()> {
     // For all of the other commands, we need to actually attach to the chip.
     //
     let mut core = attach_live(&context.cli, hubris)?;
-    let _info = core.halt()?;
+    core.halt()?;
 
     humility::msg!("core halted");
 

--- a/cmd/gpio/src/lib.rs
+++ b/cmd/gpio/src/lib.rs
@@ -278,10 +278,7 @@ fn gpio(context: &mut humility::ExecutionContext) -> Result<()> {
                             Ok(ref val) => {
                                 let arr: &[u8; 2] = val[0..2].try_into()?;
                                 let v = u16::from_le_bytes(*arr);
-                                format!(
-                                    "{}",
-                                    if v & (1 << pin) != 0 { 1 } else { 0 }
-                                )
+                                format!("{}", i32::from(v & (1 << pin) != 0))
                             }
                         }
                     );
@@ -317,10 +314,7 @@ fn gpio(context: &mut humility::ExecutionContext) -> Result<()> {
                             let v = u16::from_le_bytes(*arr);
 
                             for i in 0..16 {
-                                print!(
-                                    "{:4}",
-                                    if v & (1 << i) != 0 { 1 } else { 0 }
-                                )
+                                print!("{:4}", i32::from(v & (1 << i) != 0))
                             }
                             println!();
                         }

--- a/cmd/qspi/src/lib.rs
+++ b/cmd/qspi/src/lib.rs
@@ -464,7 +464,7 @@ fn qspi(context: &mut humility::ExecutionContext) -> Result<()> {
         let qspi_hash = funcs.get("QspiHash", 2)?;
         let qspi_read_id = funcs.get("QspiReadId", 0)?;
         // Address is optional and defaults to zero.
-        let addr = subargs.addr.or(Some(0)).unwrap() as u32;
+        let addr = subargs.addr.unwrap_or(0) as u32;
         // nbytes is optional and defaults to the size of the entire flash.
         let nbytes =
             optional_nbytes(core, &mut context, qspi_read_id, subargs.nbytes)?;
@@ -654,7 +654,7 @@ fn qspi(context: &mut humility::ExecutionContext) -> Result<()> {
         // Address is optional and defaults to zero.
         // The default can/should be done in `#[clap(...` for "address"
         // if that works for the other users of the -a flag.
-        let mut address = subargs.addr.or(Some(0)).unwrap() as u32;
+        let mut address = subargs.addr.unwrap_or(0) as u32;
         println!("addr={:?}", address);
 
         let nbytes =
@@ -729,7 +729,7 @@ fn qspi(context: &mut humility::ExecutionContext) -> Result<()> {
             updates += 1;
 
             for (i, block_result) in results.iter().enumerate() {
-                match &*block_result {
+                match block_result {
                     Err(err) => bail!(
                         "failed to read block {} at offset {}: {}",
                         i,
@@ -966,12 +966,10 @@ impl DeviceIdData {
     pub fn size(&self) -> Result<usize> {
         match self.memory_capacity {
             // This is currently limited to the codes returned from Micron MT25Q parts.
-            0 => {
-                return Err(anyhow!(
-                    "unknown size code=0x{:02x?}",
-                    self.memory_capacity
-                ))
-            }
+            0 => Err(anyhow!(
+                "unknown size code=0x{:02x?}",
+                self.memory_capacity
+            )),
             _ => Ok(1usize << (self.memory_capacity)),
         }
     }

--- a/cmd/readvar/src/lib.rs
+++ b/cmd/readvar/src/lib.rs
@@ -66,7 +66,7 @@ fn readvar_dump(
     let mut buf: Vec<u8> = vec![];
     buf.resize_with(variable.size, Default::default);
 
-    let _info = core.op_start()?;
+    core.op_start()?;
     core.read_8(variable.addr, buf.as_mut_slice())?;
     core.op_done()?;
 

--- a/cmd/ringbuf/src/lib.rs
+++ b/cmd/ringbuf/src/lib.rs
@@ -83,7 +83,7 @@ fn ringbuf_dump(
     let mut buf: Vec<u8> = vec![];
     buf.resize_with(ringbuf_var.size, Default::default);
 
-    let _info = core.op_start()?;
+    core.op_start()?;
     core.read_8(ringbuf_var.addr, buf.as_mut_slice())?;
     core.op_done()?;
 

--- a/cmd/spd/src/lib.rs
+++ b/cmd/spd/src/lib.rs
@@ -179,7 +179,7 @@ fn spd(context: &mut humility::ExecutionContext) -> Result<()> {
         let nspd = spd_data.size / SPD_SIZE;
         let mut bytes = vec![0u8; spd_data.size];
 
-        let _info = core.halt()?;
+        core.halt()?;
         let rval = core.read_8(spd_data.addr, &mut bytes);
         core.run()?;
 

--- a/humility-arch-cortex/src/etm.rs
+++ b/humility-arch-cortex/src/etm.rs
@@ -384,7 +384,7 @@ fn encode(hdr: ETM3Header) -> u8 {
     }
 }
 
-fn set(table: &mut Vec<Option<ETM3Header>>, hdr: ETM3Header) {
+fn set(table: &mut [Option<ETM3Header>], hdr: ETM3Header) {
     let val = encode(hdr) as usize;
 
     match table[val] {
@@ -782,15 +782,12 @@ pub fn etm_ingest(
             ETM3PacketState::Complete => {}
         }
 
-        match (state, hdr) {
-            (IngestState::ISyncSearching, ETM3Header::ISync) => {
-                //
-                // We have our ISync packet -- we can now ingest everything
-                // (starting with this packet).
-                //
-                state = IngestState::Ingesting;
-            }
-            (_, _) => {}
+        if let (IngestState::ISyncSearching, ETM3Header::ISync) = (state, hdr) {
+            //
+            // We have our ISync packet -- we can now ingest everything
+            // (starting with this packet).
+            //
+            state = IngestState::Ingesting;
         }
 
         if state == IngestState::Ingesting {

--- a/humility-arch-cortex/src/itm.rs
+++ b/humility-arch-cortex/src/itm.rs
@@ -122,7 +122,7 @@ pub enum ITMPayload {
     },
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ITMHeader {
     Sync,
     Overflow,
@@ -191,7 +191,7 @@ fn encode(hdr: ITMHeader) -> u8 {
     }
 }
 
-fn set(table: &mut Vec<Option<ITMHeader>>, hdr: ITMHeader) {
+fn set(table: &mut [Option<ITMHeader>], hdr: ITMHeader) {
     let val = encode(hdr) as usize;
 
     match table[val] {

--- a/humility-arch-cortex/src/scs.rs
+++ b/humility-arch-cortex/src/scs.rs
@@ -71,7 +71,7 @@ register_offs!(SWTF_CTRL, 0x0,
     pub es0, set_es0: 0;
 );
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum CoreSightClass {
     ROM,
     Component,
@@ -390,7 +390,7 @@ register!(CPUID, 0xe000_ed00,
 // therefore are willing to hard-code special case handling for, to some
 // extent.
 //
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Vendor {
     ST,
     NXP,

--- a/humility-cmd/src/idol.rs
+++ b/humility-cmd/src/idol.rs
@@ -119,7 +119,7 @@ impl<'a> IdolOperation<'a> {
         member: &HubrisStructMember,
         arg: (&String, &AttributedTy),
         val: &IdolArgument,
-        payload: &mut Vec<u8>,
+        payload: &mut [u8],
     ) -> Result<()> {
         // Now, we have to decide how to pack the argument into the payload
         //

--- a/humility-cmd/src/test.rs
+++ b/humility-cmd/src/test.rs
@@ -11,7 +11,7 @@ use std::fs::OpenOptions;
 use std::io::BufWriter;
 use std::io::Write;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum TestSource {
     KernelLog,
     UserLog,

--- a/humility-core/src/core/gdb.rs
+++ b/humility-core/src/core/gdb.rs
@@ -19,7 +19,7 @@ use xmlparser::{Token, Tokenizer};
 
 use crate::core::Core;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum GDBServer {
     OpenOCD,
     JLink,

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -282,7 +282,7 @@ pub struct HubrisFlashConfig {
     pub elf: Vec<u8>,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum HubrisArchiveDoneness {
     /// Fully load archive
     Cook,
@@ -3761,7 +3761,7 @@ impl HubrisArchive {
         let regions = self.regions(core)?;
         let nsegs = regions
             .values()
-            .fold(0, |ttl, r| ttl + if !r.attr.device { 1 } else { 0 });
+            .fold(0, |ttl, r| ttl + usize::from(!r.attr.device));
 
         macro_rules! pad {
             ($size:expr) => {
@@ -4203,7 +4203,7 @@ impl HubrisArchive {
         let archive = zip::ZipArchive::new(cursor)?;
         Self::for_each_task(archive, |path, buffer| {
             let file_name = p.join(path.file_name().unwrap());
-            std::fs::write(file_name, &buffer)?;
+            std::fs::write(file_name, buffer)?;
             Ok(())
         })?;
         Ok(())
@@ -4629,7 +4629,7 @@ pub struct HubrisEnumVariant {
     pub tag: Option<u64>,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum HubrisDiscriminant {
     Expected(HubrisGoff),
     Value(HubrisGoff, usize),
@@ -5055,7 +5055,7 @@ impl HubrisPrintFormat {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum HubrisValidate {
     ArchiveMatch,
     Booted,

--- a/humility-core/src/reflect.rs
+++ b/humility-core/src/reflect.rs
@@ -479,7 +479,7 @@ impl std::ops::Index<&str> for Struct {
     type Output = Value;
 
     fn index(&self, name: &str) -> &Self::Output {
-        &*self.members[name]
+        &self.members[name]
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.59.0"
+channel = "1.65.0"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
- ran 'cargo clippy' and fixed warnings