### PR TITLE
readme: fix 'humility jefe' flag in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -928,10 +928,10 @@ Task #7 Divide-by-zero
 Humility allows for some (well-defined) manipulation of tasks via `jefe`,
 the Hubris supervisor.  By default, `jefe` will restart any faulting task;
 when debugging, it can be useful to hold a task in the faulted state. This
-is done via the `-h` option:
+is done via the `-H` option:
 
 ```console
-% humility jefe -h ping
+% humility jefe -H ping
 humility: attached via ST-Link
 humility: successfully changed disposition for ping
 ```

--- a/cmd/jefe/src/lib.rs
+++ b/cmd/jefe/src/lib.rs
@@ -7,10 +7,10 @@
 //! Humility allows for some (well-defined) manipulation of tasks via `jefe`,
 //! the Hubris supervisor.  By default, `jefe` will restart any faulting task;
 //! when debugging, it can be useful to hold a task in the faulted state. This
-//! is done via the `-h` option:
+//! is done via the `-H` option:
 //!
 //! ```console
-//! % humility jefe -h ping
+//! % humility jefe -H ping
 //! humility: attached via ST-Link
 //! humility: successfully changed disposition for ping
 //! ```


### PR DESCRIPTION
- -h flag is to print help info, -H is to hold a task in the faulted state