### PR TITLE
ci: add `--all` option to `cargo clippy`.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,4 +142,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --profile=ci -- -D warnings
+          args: --all --profile=ci -- -D warnings

--- a/humility.nix
+++ b/humility.nix
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage rec {
 
   checkPhase = ''
     ${cargo}/bin/cargo fmt --all --check
-    ${cargo}/bin/cargo clippy --profile=ci -- -D warnings
+    ${cargo}/bin/cargo clippy --all --profile=ci -- -D warnings
     ${cargo}/bin/cargo test
   '';
 


### PR DESCRIPTION
This will encourage clippy to check xtask as well.  I think this is why https://github.com/rivosinc/humility/pull/44 was able to slip through.