### PR TITLE
GDB Quality of life improvements

### DIFF
--- a/cmd/gdb/src/lib.rs
+++ b/cmd/gdb/src/lib.rs
@@ -130,14 +130,7 @@ pub fn gdb(context: &mut humility::ExecutionContext) -> Result<()> {
 
     let mut gdb_cmd = None;
 
-    const GDB_NAMES: [&str; 5] = [
-        "arm-none-eabi-gdb",
-        "riscv32-none-elf-gdb",
-        "riscv32-unknown-elf-gdb",
-        "gdb-multiarch",
-        "gdb",
-    ];
-    for candidate in &GDB_NAMES {
+    for candidate in hubris.arch.as_ref().unwrap().get_gdbs() {
         if Command::new(candidate)
             .arg("--version")
             .stdout(Stdio::piped())
@@ -151,7 +144,10 @@ pub fn gdb(context: &mut humility::ExecutionContext) -> Result<()> {
 
     // Select the GDB command
     let gdb_cmd = gdb_cmd.ok_or_else(|| {
-        anyhow::anyhow!("GDB not found.  Tried: {:?}", GDB_NAMES)
+        anyhow::anyhow!(
+            "GDB not found.  Tried: {:?}",
+            hubris.arch.as_ref().unwrap().get_gdbs()
+        )
     })?;
 
     // If OpenOCD is requested, then run it in a subprocess here, with an RAII

--- a/humility-core/src/arch/arm.rs
+++ b/humility-core/src/arch/arm.rs
@@ -399,6 +399,10 @@ impl Arch for ARMArch {
 
         rval
     }
+
+    fn get_gdbs(&self) -> &[&str] {
+        &["arm-none-eabi-gdb", "gdb-multi-arch", "gdb"]
+    }
 }
 
 /// Looks up the jump target type of the previously-disassembled instruction

--- a/humility-core/src/arch/mod.rs
+++ b/humility-core/src/arch/mod.rs
@@ -110,6 +110,9 @@ pub trait Arch {
         cs: &Capstone,
         isntr: &capstone::Insn,
     ) -> Option<HubrisTarget>;
+
+    /// Returns a list of possible GDB executable names for this architeture
+    fn get_gdbs(&self) -> &[&str];
 }
 
 impl Debug for dyn Arch {

--- a/humility-core/src/arch/rv.rs
+++ b/humility-core/src/arch/rv.rs
@@ -268,4 +268,15 @@ impl Arch for RVArch {
 
         rval
     }
+
+    fn get_gdbs(&self) -> &[&str] {
+        &[
+            "riscv32-none-elf-gdb",
+            "riscv32-unknown-elf-gdb",
+            "riscv64-none-elf-gdb",
+            "riscv64-unknown-elf-gdb",
+            "gdb-multi-arch",
+            "gdb",
+        ]
+    }
 }


### PR DESCRIPTION
This adds the ability to specify the gdb port on the command line, and improves how the gdb executable is found.  

This also removes the need for hubris to generate `openocd.gdb` files. They will be ignored by humility from this update forward.  This gives humility full control over how gdb is started.  I think we should leave `openocd.gdb` generation in hubris though, as it can be used with cargo xtask gdb.